### PR TITLE
Update Proxmox.php: fix body to "form_params"

### DIFF
--- a/src/Proxmox.php
+++ b/src/Proxmox.php
@@ -123,7 +123,7 @@ class Proxmox
                     'exceptions' => false,
                     'cookies' => $cookies,
                     'headers' => $headers,
-                    'body' => $params,
+                    'form_params' => $params,
                 ]);
                 break;
             case 'PUT':
@@ -132,7 +132,7 @@ class Proxmox
                     'exceptions' => false,
                     'cookies' => $cookies,
                     'headers' => $headers,
-                    'body' => $params,
+                    'form_params' => $params,
                 ]);
                 break;
             case 'DELETE':
@@ -141,7 +141,7 @@ class Proxmox
                     'exceptions' => false,
                     'cookies' => $cookies,
                     'headers' => $headers,
-                    'body' => $params,
+                    'form_params' => $params,
                 ]);
                 break;
             default:


### PR DESCRIPTION
Fix #15

Fixes Guzzle6 error: 
```
Passing in the "body" request option as an array to send a POST request has been deprecated. Please use the "form_params" request option to send a application/x-www-form-urlencoded request, or a the "multipart" request option to send a
   multipart/form-data request.
```