### PR TITLE
Make this plugin compatible with guzzle 7.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.5.0",
         "lib-curl": "*",
-        "guzzlehttp/guzzle": "~6.0 || ~7.0"
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
I updated the definition of the composer requirement of guzzlehttp to also allow minor versions like 7.0.1.