### PR TITLE
Guzzle 7 replaced request option 'exceptions' with 'http_errors'

### DIFF
--- a/src/Proxmox.php
+++ b/src/Proxmox.php
@@ -116,7 +116,7 @@ class Proxmox
             case 'GET':
                 return $this->httpClient->get($url, [
                     'verify' => false,
-                    'exceptions' => false,
+                    'http_errors' => false,
                     'cookies' => $cookies,
                     'query' => $params,
                 ]);
@@ -128,7 +128,7 @@ class Proxmox
                 ];
                 return $this->httpClient->request($method, $url, [
                     'verify' => false,
-                    'exceptions' => false,
+                    'http_errors' => false,
                     'cookies' => $cookies,
                     'headers' => $headers,
                     'form_params' => $params,
@@ -210,7 +210,7 @@ class Proxmox
         $loginUrl = $this->credentials->getApiUrl() . '/json/access/ticket';
         $response = $this->httpClient->post($loginUrl, [
             'verify' => false,
-            'exceptions' => false,
+            'http_errors' => false,
             'form_params' => [
                 'username' => $this->credentials->getUsername(),
                 'password' => $this->credentials->getPassword(),


### PR DESCRIPTION
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md
"Request option exception is removed. Please use http_errors."